### PR TITLE
Initial implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    sass (3.4.16)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  compass-import-once (>= 1.0.5)
+  sass (~> 3.4)

--- a/README.md
+++ b/README.md
@@ -1,26 +1,151 @@
 # Stencil Icon
 
-Stencil Icon Component
+A container for displaying SVG icons from a `<symbol>`-based SVG sprite.
 
-[Link to demo](#)
+**View demo (coming soon)**
 
 ## Requirements
 
-- Sass
-- AMD loader
-- Dust templating
+- AdaptiveJS 2.1 or greater
 
 ## Installation
 
-Installation instructions. Be as brief as possible without leaving out necessary requirements.
+```shell
+cd my/adaptive/project
+grunt component:install:icon
+```
 
 ## Usage
 
-- How to
+The Icon component ships with a default icon set, [Shoppicon](http://github.com/ry5n/shoppicon). Usage depends in whether you want to use the default set, or a custom set.
 
-## Development
+### Default icon set
 
-* run `npm install`
-* run `bower install`
-* run `grunt serve`
-* navigate to [localhost:3000/tests/visual](http://localhost:3000/tests/visual)
+1. In your adaptive project, open `app/global/base-view.js`, and add the following dependency:
+
+    ```javascript
+    define(['$', ..., 'text!bower_components/shoppicon/svg-sprite/shoppicon.svg'], function($, ..., icons) {...});
+    ```
+
+    Then, within the views’s returned context, add a key for the icon sprite:
+
+    ```javascript
+    return {
+        preProcess: function(context) {...},
+        postProcess: function(context) {...},
+        context: {
+            ...
+            icons: icons,
+        },
+    };
+    ```
+
+    Finally, within `app/global/base.dust`, include the svg sprite *at the very top of the body tag*, like so:
+
+    ```html
+    {body|openTag|s}
+        <div hidden>{icons|s}</div>
+        
+        {+bodyBlock}
+        ...
+        {/bodyBlock}
+    </body>
+    ```
+
+2. Use the Icon component’s dust helper to render icons. For example, to show a hamburger icon:
+
+    ```html
+    {@c-icon set="shoppicon" name="menu" /}
+    ```
+
+
+### Custom icon set
+
+1. To use a custom icon set, you’ll need to build the SVG sprite using a separate tool, such as (grunt-svgstore)[https://github.com/FWeinb/grunt-svgstore], or (grunt-iconpack)[https://github.com/ry5n/grunt-iconpack]. Preferably, build your sprite with ids that are prefixed with `icon-`.
+
+2. Follow step 2 in “Default icon set” above, replacing the path to the shoppicon sprite with the path to your custom sprite.
+
+3. Use the Icon component’s dust helper to render icons. If your prefix is set correctly, you don’t need the `set` parameter. For example, to show a hamburger icon:
+
+    ```html
+    {@c-icon name="menu" /}
+    ```
+
+### Changing the icon dynamically
+
+To update the icon’s displayed symbol from script, you need to enable dynamic mode in the dust helper:
+
+```html
+{@c-icon name="menu" dynamic="true" /}
+```
+
+Then, you can update the name dynamically from script:
+
+```javascript
+// Get the name of the currently-displayed icon, without the prefix:
+$('#something .c-icon').data('component').name();
+
+// Set the icon
+$('#something .c-icon').data('component').name('arrow-left');
+
+// Get the icon’s prefix, minus the dash.
+$('#something .c-icon').data('component').prefix;
+// ← `icon`
+```
+
+
+## API
+
+### Dust helper parameters
+
+Param name | Type          | Description
+:--------- | :------------ | :----------
+class      | String        | Adds values to the `class` attribute of the root element
+id         | String        | Sets the `id` attribute of the underlying select element
+name       | String        | Name of the icon to display from the sprite. Consult your icon set of choice for a list of available icons
+set        | String        | Value of the prefix used in the icon sprite, the dash
+title      | String        | Text equivalent for screen readers. Only use this if there is no text label elsewhere in the UI.
+
+### Dust helper bodies
+
+_none_
+
+### Sass configurable variables
+
+Variable name     | Type      | Description
+:---------------- | :-------- | :----------
+$icon__size       | Length    | The width and height for the icon.
+
+### UI options
+
+_none_
+
+### UI methods
+
+The component’s UI script instance is available via `$('.c-icon').data('component')`.
+
+Method name | Parameters | Description
+:---------- | :--------- | :----------------
+name        | [value]    | With no parameters, returns the name of the currently-displayed icon, without the prefix. With a string parameter, changes the displayed icon by setting the name to the new value.
+
+### UI events
+
+_none_
+
+## Contributing
+
+First, read the Adaptive component documentation, especially the pages on creating components and the Stencil authoring guide. Then, clone the repo:
+
+- `git clone git@github.com:mobify/stencil-icon.git`
+- `cd stencil-icon`
+- `npm install && bower install`
+- Create a branch for your changes and begin development.
+- Run the test server during development to check your work (see below).
+
+### Testing
+
+Visual tests provide a way to describe the features of a component in a spec format and manually check functionality of a component. To run tests:
+
+- `grunt serve`
+- Note the local port on which the test server is running (defaults to 3000)
+- Navigate to [localhost:{port}/tests/visual](http://localhost:3000/tests/visual)

--- a/_icon.scss
+++ b/_icon.scss
@@ -1,10 +1,10 @@
-// icon
+// Stencil Icon
 // ===
 
 // Configurable Variables
 // ---
 
-$icon__variable-name: true !default;
+$icon__size: 25px !default;
 
 
 // Dependencies
@@ -18,13 +18,14 @@ $icon__variable-name: true !default;
 // ---
 
 .c-icon {
-    // Your component styles go here
-}
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: $icon__size;
+    height: $icon__size;
 
+    fill: currentColor;
 
-// Icon sub-component
-// ---
-
-.c-icon__sub-component {
-    // Your component styles go here
+    color: inherit;
+    vertical-align: middle;
 }

--- a/bower.json
+++ b/bower.json
@@ -29,9 +29,10 @@
   "dependencies": {
     "stencil-variables": "mobify/stencil-variables#*",
     "level": ">=0.1.0",
-    "spline": "~1.0.1"
+    "spline": "~1.0.1",
+    "shoppicon": "ry5n/shoppicon#~0.0.4"
   },
   "devDependencies": {
-      "stencil-spec": "mobify/stencil-spec#dev"
+    "stencil-spec": "mobify/stencil-spec#dev"
   }
 }

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -21,6 +21,13 @@ define(['$'], function($) {
      */
     return {
         init: function($el, options) {
+            // Recreate jQuery object with correct selector
+            //
+            // TODO: This shouldn’t be needed but is, for Adaptive, even after
+            // this change: https://github.com/mobify/adaptivejs/commit/dcb71b4738c2d59aa79f8e21a978a5a24bc03756
+            //
+            $el = $($el);
+
             // If already initialized, return the instance; otherwise, create it
             // and expose it through jQuery’s data store.
             return $el.data('component') || $el.data('component', new Icon($el, options));

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -1,0 +1,34 @@
+define(function(require) {
+    /**
+     * Constructor
+     */
+    var Icon = function($el, options) {
+        // Component instance properties.
+        this.$el = $el;
+        this.$use = this.$el.find('use').eq(0);
+        this.prefix = this.$use.attr('xlink:href').split('-').shift();
+
+        // Event handlers here.
+
+        // Immediately invoke any methods needed to set up initial state here.
+    };
+
+    Icon.prototype.name = function(newName) {
+        if (newName === undefined) {
+            return this.$use.attr('xlink:href').replace(this.prefix + '-', '');
+        } else {
+            this.$use.attr('xlink:href', this.prefix + '-' + newName);
+        }
+    };
+
+    /**
+     * Export the init method required by AdaptiveJS.
+     */
+    return {
+        init: function($el, options) {
+            // If already initialized, return the instance; otherwise, create it
+            // and expose it through jQuery’s data store.
+            return $el.data('component') || $el.data('component', new Icon($el, options));
+        }
+    };
+});

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -1,4 +1,4 @@
-define(function(require) {
+define(['$'], function($) {
     /**
      * Constructor
      */

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -7,10 +7,6 @@ define(function(require) {
         this.$el = $el;
         this.$use = this.$el.find('use').eq(0);
         this.prefix = this.$use.attr('xlink:href').split('-').shift();
-
-        // Event handlers here.
-
-        // Immediately invoke any methods needed to set up initial state here.
     };
 
     Icon.prototype.name = function(newName) {

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -6,14 +6,13 @@ define(function(require) {
         // Component instance properties.
         this.$el = $el;
         this.$use = this.$el.find('use').eq(0);
-        this.prefix = this.$use.attr('xlink:href').split('-').shift();
     };
 
     Icon.prototype.name = function(newName) {
         if (newName === undefined) {
-            return this.$use.attr('xlink:href').replace(this.prefix + '-', '');
+            return this.$use.attr('xlink:href').replace(/^#/, '');
         } else {
-            this.$use.attr('xlink:href', this.prefix + '-' + newName);
+            this.$use.attr('xlink:href', '#' + newName);
         }
     };
 

--- a/icon-ui.js
+++ b/icon-ui.js
@@ -21,13 +21,6 @@ define(['$'], function($) {
      */
     return {
         init: function($el, options) {
-            // Recreate jQuery object with correct selector
-            //
-            // TODO: This shouldn’t be needed but is, for Adaptive, even after
-            // this change: https://github.com/mobify/adaptivejs/commit/dcb71b4738c2d59aa79f8e21a978a5a24bc03756
-            //
-            $el = $($el);
-
             // If already initialized, return the instance; otherwise, create it
             // and expose it through jQuery’s data store.
             return $el.data('component') || $el.data('component', new Icon($el, options));

--- a/icon.dust
+++ b/icon.dust
@@ -1,3 +1,8 @@
-<div {?id}id="{.}"{/id} class="c-icon {class}" {?role}role="{.}"{/role}>
-    Component stuff goes here!
-</div>
+<svg class="c-icon {class}"
+    {?id}id="{id}"{/id}
+    {?title}title="{title}"{/title}
+    {?dynamic}data-adaptivejs-component="stencil-icon"{/dynamic}
+>
+    {?title}<title>{title}</title>{/title}
+    <use xlink:href="#{?set}{set}{:else}icon{/set}-{name}"></use>
+</svg>

--- a/icon.dust
+++ b/icon.dust
@@ -4,5 +4,8 @@
     {?dynamic}data-adaptivejs-component="stencil-icon"{/dynamic}
 >
     {?title}<title>{title}</title>{/title}
-    <use xlink:href="#{?set}{set}{:else}icon{/set}-{name}"></use>
+    <use xlink:href="#{name}"></use>
 </svg>
+
+{! Usage in other components will use `default` namespace? !}
+{! {@c-icon name="default-plus" /} !}

--- a/package.json
+++ b/package.json
@@ -10,18 +10,21 @@
     "url": "http://github.com/mobify/stencil-icon.git"
   },
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "^2.1.4"
+  },
   "devDependencies": {
+    "adaptivejs": "~2.1.0-beta2",
+    "dustjs-linkedin": "2.3.3",
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "2.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-stencil-dust": "git+ssh://git@github.com:mobify/grunt-stencil-dust.git#master",
     "load-grunt-tasks": "~0.4.0",
-    "dustjs-linkedin": "2.3.3",
     "requirejs": "^2.1.0",
-    "adaptivejs": "~2.1.0-beta2",
-    "grunt-stencil-dust": "git+ssh://git@github.com:mobify/grunt-stencil-dust.git#master"
+    "requirejs-text": "^2.0.12"
   }
 }

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -52,6 +52,7 @@ define(function(require) {
 
             // Test dynamic icons
             var $cycler = $('#cycler');
+            var $inputter = $('#inputter');
             var icons = ['arrow-up', 'arrow-right', 'arrow-down', 'arrow-left'];
             var cycleCount = 0;
 
@@ -60,6 +61,17 @@ define(function(require) {
                 cycleCount = cycleCount >= 3 ? 0 : cycleCount + 1;
                 $cycler.data('component').name(icons[cycleCount]);
             }, 1000);
+
+            $('#inputter-input').on('keydown', function(e) {
+                if (e.which === 13) {
+                    $('#inputter-button').trigger('click');
+                    this.setSelectionRange(0, this.value.length);
+                }
+            });
+
+            $('#inputter-button').on('click', function() {
+                $inputter.data('component').name($.trim($('#inputter-input').val()));
+            });
         } else {
             console.log(err);
         }

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -2,25 +2,27 @@ require.config({
     paths: {
         'dust-full': '../../node_modules/dustjs-linkedin/dist/dust-full',
         'adaptivejs': '../../node_modules/adaptivejs',
+        '$': '../../node_modules/jquery/dist/jquery',
+        'text': '../../node_modules/requirejs-text/text',
     },
     shim: {
         'dust-full': {
             'exports': 'dust'
+        },
+        '$': {
+            'exports': 'jQuery'
         }
     },
 });
 
-require([
-    'dust-full',
-    'adaptivejs/lib/dust-component-helper',
-    'adaptivejs/lib/dust-component-sugar',
-    '../../tmp/templates'
-], function(
-    dust,
-    componentHelper,
-    componentSugar,
-    templates
-) {
+define(function(require) {
+    var dust = require('dust-full');
+    var componentHelper = require('adaptivejs/lib/dust-component-helper');
+    var componentSugar = require('adaptivejs/lib/dust-component-sugar');
+    var ui = require('../../icon-ui');
+    var templates = require('../../tmp/templates');
+    var icons = require('text!../../bower_components/shoppicon/svg-sprite/shoppicon.svg');
+    var $ = require('$');
     var context;
 
     // Register helpers for precompiled component templates.
@@ -32,13 +34,32 @@ require([
     // Define any context required for the tests:
     var context = {
         repo: 'https://github.com/mobify/stencil-icon',
-        selectMarkup: 'Insert example markup here',
+        icons: icons,
     };
 
     // Render
     dust.render('tests', context, function(err, out) {
         if (!err) {
             document.querySelector('body').innerHTML = out;
+
+            $('[data-adaptivejs-component="stencil-icon"]').each(function(i, el) {
+                var $component = $(el);
+
+                // Initialize
+                ui.init($component);
+                $component.attr('data-adaptivejs-component-processed', '');
+            });
+
+            // Test dynamic icons
+            var $cycler = $('#cycler');
+            var icons = ['arrow-up', 'arrow-right', 'arrow-down', 'arrow-left'];
+            var cycleCount = 0;
+
+            window.setInterval(function() {
+                // debugger;
+                cycleCount = cycleCount >= 3 ? 0 : cycleCount + 1;
+                $cycler.data('component').name(icons[cycleCount]);
+            }, 1000);
         } else {
             console.log(err);
         }

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -59,7 +59,7 @@ define(function(require) {
             window.setInterval(function() {
                 // debugger;
                 cycleCount = cycleCount >= 3 ? 0 : cycleCount + 1;
-                $cycler.data('component').name(icons[cycleCount]);
+                $cycler.data('component').name('shoppicon-' + icons[cycleCount]);
             }, 1000);
 
             $('#inputter-input').on('keydown', function(e) {

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -8,8 +8,8 @@
     }
 
     .c-icon.c--large {
-        width: 32px;
-        height: 32px;
+        width: 50px;
+        height: 50px;
     }
 </style>
 
@@ -19,17 +19,17 @@
             {@c-icon set="shoppicon" name="check" /}
         {/c-spec__case}
 
-        {@c-spec__case expect="It should be colorable via CSS (green)."}
+        {@c-spec__case expect="It should ge green."}
             {@c-icon class="c--success" set="shoppicon" name="check" /}
         {/c-spec__case}
 
-        {@c-spec__case expect="It should support different sizes via CSS (32 × 32)."}
+        {@c-spec__case expect="I should render 50 × 50px."}
             {@c-icon class="c--large" set="shoppicon" name="check" /}
         {/c-spec__case}
     {/c-spec__test}
 
     {@c-spec__test describe="Dynamic Icon"}
-        {@c-spec__case expect="It should be changeable via script (cycle through arrow directions)."}
+        {@c-spec__case expect="It should cycle through arrow directions."}
             {@c-icon id="cycler" set="shoppicon" name="arrow-up" dynamic="true" /}
         {/c-spec__case}
     {/c-spec__test}

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -1,5 +1,4 @@
 <div hidden>{icons|s}</div>
-{@c-iconset path="bower_components/my-iconset/my-spritesheet.svg" /}
 
 <style>
     /* Test-specific fixture styles go here. */

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -1,11 +1,36 @@
+<div hidden>{icons|s}</div>
+{@c-iconset path="bower_components/my-iconset/my-spritesheet.svg" /}
+
 <style>
     /* Test-specific fixture styles go here. */
+    .c-icon.c--success {
+        fill: hsl(165, 80%, 40%);
+    }
+
+    .c-icon.c--large {
+        width: 32px;
+        height: 32px;
+    }
 </style>
 
 {@c-spec for="Icon Component" repository=repo}
-    {@c-spec__test describe=".c-icon"}
-        {@c-spec__case expect="Should have feature A"}
-            {@c-icon /}
+    {@c-spec__test describe="Icon"}
+        {@c-spec__case expect="It should render a checkmark 25 × 25px."}
+            {@c-icon set="shoppicon" name="check" /}
+        {/c-spec__case}
+
+        {@c-spec__case expect="It should be colorable via CSS (green)."}
+            {@c-icon class="c--success" set="shoppicon" name="check" /}
+        {/c-spec__case}
+
+        {@c-spec__case expect="It should support different sizes via CSS (32 × 32)."}
+            {@c-icon class="c--large" set="shoppicon" name="check" /}
+        {/c-spec__case}
+    {/c-spec__test}
+
+    {@c-spec__test describe="Dynamic Icon"}
+        {@c-spec__case expect="It should be changeable via script (cycle through arrow directions)."}
+            {@c-icon id="cycler" set="shoppicon" name="arrow-up" dynamic="true" /}
         {/c-spec__case}
     {/c-spec__test}
 {/c-spec}

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -29,27 +29,27 @@
 {@c-spec for="Icon Component" repository=repo}
     {@c-spec__test describe="Icon"}
         {@c-spec__case expect="It should render a checkmark 25 × 25px."}
-            {@c-icon set="shoppicon" name="check" /}
+            {@c-icon name="shoppicon-check" /}
         {/c-spec__case}
 
         {@c-spec__case expect="It should ge green."}
-            {@c-icon class="c--success" set="shoppicon" name="check" /}
+            {@c-icon class="c--success" name="shoppicon-check" /}
         {/c-spec__case}
 
         {@c-spec__case expect="I should render 50 × 50px."}
-            {@c-icon class="c--large" set="shoppicon" name="check" /}
+            {@c-icon class="c--large" name="shoppicon-check" /}
         {/c-spec__case}
     {/c-spec__test}
 
     {@c-spec__test describe="Dynamic Icon"}
         {@c-spec__case expect="It should cycle through arrow directions."}
-            {@c-icon id="cycler" set="shoppicon" name="arrow-up" dynamic="true" /}
+            {@c-icon id="cycler" name="shoppicon-arrow-up" dynamic="true" /}
         {/c-spec__case}
 
         {@c-spec__case expect="It should be changeable via script."}
-            {@c-icon id="inputter" set="shoppicon" name="info" dynamic="true" /}
+            {@c-icon id="inputter" name="shoppicon-info" dynamic="true" /}
             <span class="input-box">
-                <input id="inputter-input" type="text" value="info" />
+                <input id="inputter-input" type="text" value="shoppicon-info" />
                 <button id="inputter-button" type="button">Update</button>
             </span>
         {/c-spec__case}

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -11,6 +11,20 @@
         width: 50px;
         height: 50px;
     }
+
+    .input-box {
+        display: inline-block;
+        padding-left: 1.5em;
+        vertical-align: middle;
+    }
+
+    .input-box input,
+    .input-box button {
+        box-sizing: border-box;
+        min-height: 40px;
+        padding: 0.25em 0.5em;
+        -webkit-appearance: none;
+    }
 </style>
 
 {@c-spec for="Icon Component" repository=repo}
@@ -31,6 +45,14 @@
     {@c-spec__test describe="Dynamic Icon"}
         {@c-spec__case expect="It should cycle through arrow directions."}
             {@c-icon id="cycler" set="shoppicon" name="arrow-up" dynamic="true" /}
+        {/c-spec__case}
+
+        {@c-spec__case expect="It should be changeable via script."}
+            {@c-icon id="inputter" set="shoppicon" name="info" dynamic="true" /}
+            <span class="input-box">
+                <input id="inputter-input" type="text" value="info" />
+                <button id="inputter-button" type="button">Update</button>
+            </span>
         {/c-spec__case}
     {/c-spec__test}
 {/c-spec}


### PR DESCRIPTION
This is an initial implementation of the Icon component. Right now it only supports SVG. I think we also want to support icon fonts, but that makes things much harder. For now I just want to get initial feedback on the API and usage. Basically, this component renders an icon from an SVG sprite. For details, see the Details section.

Status: **Ready for Initial Review**
Owner: @ry5n
Reviewers: @jeffkamo @avelinet @yourpalsonja and everyone
## Details
- Declares a default icon set ([shoppicon](http://github.com/ry5n/shoppicon)) as a Bower dependency. However, as a developer you need to add the sprite to the page yourself. This is a little disappointing given Stencil’s goal of “it just works” but I think it’s a pragmatic decision for the time being. We’ll need to have a how-to in the docs.
- The dust file assumes your svg symbol ids are formatted like so: `id="{prefix}-{name}"`, and requires you to pass the prefix as a param if it isn’t `icon`. This could be awkward.
- You can declare an icon as scriptable with the `dynamic="true"` param. The main use case here is to change the icon in a view script without having to muck with the component’s internals – instead, you use the public interface in the form of the `name` method: `$('#my-icon').data('component').name('something')`. The fact that you need to opt-in to the UI script should help performance.
- The `title` param allows you to make the icon available to screen readers.
## Jira Tickets:
- [STEN-13]
## Todos:
- [ ] Engineer +1
- [ ] UI Dev +1
## How to Test
- clone this repo
- `cd stencil-icon`
- `npm install && bower install && bundle install`
- run `grunt serve`
- Check the command line output to determine which port the server started at (defaults to 3000)
- Navigate to `localhost:{port}/tests/visual/`
